### PR TITLE
eg/sv - add controller for users

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -77,7 +77,7 @@ public class UsersController extends ApiController {
     }
 
     
-    @Operation(summary = "Toggle the admin field")
+    @Operation(summary = "Toggle the admin field") 
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/toggleAdmin")
     public Object toggleAdmin( @Parameter(name = "id", description = "Long, id number of user to toggle their admin field", example = "1", required = true) @RequestParam Long id){
@@ -90,28 +90,28 @@ public class UsersController extends ApiController {
     }
 
 
-    @Operation(summary = "Toggle the professor field")
+    @Operation(summary = "Toggle the professor field") 
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/toggleDriver")
-    public Object toggleDriver( @Parameter(name = "id", description = "Long, id number of user to toggle their driver field", example = "1", required = true) @RequestParam Long id){
+    @PostMapping("/toggleProfessor")
+    public Object toggleProfessor( @Parameter(name = "id", description = "Long, id number of user to toggle their professor field", example = "1", required = true) @RequestParam Long id){
 
         User user = userRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
         user.setProfessor(!user.getProfessor());
         userRepository.save(user);
-        return genericMessage("User with id %s has toggled driver status to %s".formatted(id, user.getProfessor()));
+        return genericMessage("User with id %s has toggled professor status to %s".formatted(id, user.getProfessor()));
     }
 
-    @Operation(summary = "Toggle the student field")
+    @Operation(summary = "Toggle the student field") 
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/toggleRider")
-    public Object toggleRider( @Parameter(name = "id") @RequestParam Long id){
+    @PostMapping("/toggleStudent")
+    public Object toggleStudent( @Parameter(name = "id") @RequestParam Long id){
         User user = userRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
         user.setStudent(!user.getStudent());
         userRepository.save(user);
-        return genericMessage("User with id %s has toggled rider status to %s".formatted(id, user.getStudent()));
+        return genericMessage("User with id %s has toggled student status to %s".formatted(id, user.getStudent()));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -6,9 +6,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.rec.errors.EntityNotFoundException;
 
 import edu.ucsb.cs156.rec.entities.User;
 import edu.ucsb.cs156.rec.repositories.UserRepository;
@@ -44,5 +49,68 @@ public class UsersController extends ApiController {
         Iterable<User> users = userRepository.findAll();
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary = "Get user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/get")
+    public User users(
+            @Parameter(name = "id", description = "Long, id number of user to get", example = "1", required = true) @RequestParam Long id)
+            throws JsonProcessingException {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+        return user;
+    }
+
+    @Operation(summary = "Delete a user (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/delete")
+    public Object deleteUser_Admin(
+            @Parameter(name = "id", description = "Long, id number of user to delete", example = "1", required = true) @RequestParam Long id) {
+              User user = userRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+          userRepository.delete(user);
+
+        return genericMessage("User with id %s deleted".formatted(id));
+    }
+
+    
+    @Operation(summary = "Toggle the admin field")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleAdmin")
+    public Object toggleAdmin( @Parameter(name = "id", description = "Long, id number of user to toggle their admin field", example = "1", required = true) @RequestParam Long id){
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setAdmin(!user.getAdmin());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled admin status to %s".formatted(id, user.getAdmin()));
+    }
+
+
+    @Operation(summary = "Toggle the driver field")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleDriver")
+    public Object toggleDriver( @Parameter(name = "id", description = "Long, id number of user to toggle their driver field", example = "1", required = true) @RequestParam Long id){
+
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setDriver(!user.getDriver());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled driver status to %s".formatted(id, user.getDriver()));
+    }
+
+    @Operation(summary = "Toggle the rider field")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleRider")
+    public Object toggleRider( @Parameter(name = "id") @RequestParam Long id){
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setRider(!user.getRider());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled rider status to %s".formatted(id, user.getRider()));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -19,6 +19,7 @@ import edu.ucsb.cs156.rec.entities.User;
 import edu.ucsb.cs156.rec.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
 
 /**
  * This is a REST controller for getting information about the users.
@@ -89,7 +90,7 @@ public class UsersController extends ApiController {
     }
 
 
-    @Operation(summary = "Toggle the driver field")
+    @Operation(summary = "Toggle the professor field")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/toggleDriver")
     public Object toggleDriver( @Parameter(name = "id", description = "Long, id number of user to toggle their driver field", example = "1", required = true) @RequestParam Long id){
@@ -97,20 +98,20 @@ public class UsersController extends ApiController {
         User user = userRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
-        user.setDriver(!user.getDriver());
+        user.setProfessor(!user.getProfessor());
         userRepository.save(user);
-        return genericMessage("User with id %s has toggled driver status to %s".formatted(id, user.getDriver()));
+        return genericMessage("User with id %s has toggled driver status to %s".formatted(id, user.getProfessor()));
     }
 
-    @Operation(summary = "Toggle the rider field")
+    @Operation(summary = "Toggle the student field")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/toggleRider")
     public Object toggleRider( @Parameter(name = "id") @RequestParam Long id){
         User user = userRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
-        user.setRider(!user.getRider());
+        user.setStudent(!user.getStudent());
         userRepository.save(user);
-        return genericMessage("User with id %s has toggled rider status to %s".formatted(id, user.getRider()));
+        return genericMessage("User with id %s has toggled rider status to %s".formatted(id, user.getStudent()));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -32,5 +32,10 @@ public class User {
   private boolean emailVerified;
   private String locale;
   private String hostedDomain;
-  private boolean admin;
+  @Builder.Default
+  private boolean admin = false;
+  @Builder.Default
+  private boolean professor = false;
+  @Builder.Default
+  private boolean student = false;
 }

--- a/src/main/java/edu/ucsb/cs156/rec/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/rec/repositories/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends CrudRepository<User, Long> {
    * @return Optional of User (empty if not found)
    */
   Optional<User> findByEmail(String email);
+  Iterable<User> findByProfessor(boolean professor);
+
 }

--- a/src/main/resources/db/migration/changes/Users.json
+++ b/src/main/resources/db/migration/changes/Users.json
@@ -97,6 +97,18 @@
                     "name": "PICTURE_URL",
                     "type": "VARCHAR(255)"
                   }
+                },
+                {
+                  "column": {
+                    "name": "PROFESSOR",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STUDENT",
+                    "type": "BOOLEAN"
+                  }
                 }]
               ,
               "tableName": "USERS"

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
@@ -13,14 +13,21 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -70,4 +77,362 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
 
   }
+
+  //new tests here
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void api_users__admin_logged_in__returns_a_user_that_exists() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+      User user1 = User.builder().email("cgaucho@ucsb.edu").id(42L).build();
+      when(userRepository.findById(eq(42L))).thenReturn(Optional.of(user1));
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/admin/users/get?id=42"))
+              .andExpect(status().isOk()).andReturn();
+
+      // assert
+
+      verify(userRepository, times(1)).findById(42L);
+      String expectedJson = mapper.writeValueAsString(user1);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void api_users__admin_logged_in__search_for_user_that_does_not_exist() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+
+      when(userRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/admin/users/get?id=7"))
+              .andExpect(status().isNotFound()).andReturn();
+
+      // assert
+
+      // verify(userRepository, times(1)).findById(7L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("EntityNotFoundException", json.get("type"));
+      assertEquals("User with id 7 not found", json.get("message"));
+  }
+
+
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_delete_a_user() throws Exception {
+          // arrange
+          User user1 = User.builder().email("cgaucho@ucsb.edu").id(15L).build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(user1));
+
+          // act
+          MvcResult response = mockMvc.perform(
+                          delete("/api/admin/users/delete?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).delete(any());
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_delete_non_existant_user_and_gets_right_error_message()
+                  throws Exception {
+          // arrange
+
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+          // act
+          MvcResult response = mockMvc.perform(
+                          delete("/api/admin/users/delete?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_admin_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(true)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled admin status to true", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_admin_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled admin status to false", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggleAdmin_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+  // professor toggle tests
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_professor_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(true)
+          .build();
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleProfessor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled professor status to true", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_professor_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleProfessor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled professor status to false", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggle_professor_for_non_existant_user_and_gets_right_error_message() throws Exception {
+
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleProfessor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+
+  // student toggle tests
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_student_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(true)
+          .build();
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleStudent?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled student status to true", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_student_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleStudent?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled student status to false", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggle_student_for_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleStudent?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
 }
+


### PR DESCRIPTION
Adds backend functionality and tests for users controller for issue #12
Adds following functionality to swagger:
- Can search for users by id or get a list of all users
- Can delete a user
- Can toggle a user to be an admin, student, or professor
- Passes all tests