### PR TITLE
pc - test coverage for ApiController independent of any other controller

### DIFF
--- a/src/test/java/edu/ucsb/cs156/rec/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/ApiControllerTests.java
@@ -1,0 +1,61 @@
+package edu.ucsb.cs156.rec.controllers;
+
+import edu.ucsb.cs156.rec.testconfig.TestConfig;
+import edu.ucsb.cs156.rec.ControllerTestCase;
+import edu.ucsb.cs156.rec.repositories.UserRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WebMvcTest(controllers = DummyController.class)
+@Import(TestConfig.class)
+public class ApiControllerTests extends ControllerTestCase {
+
+        @MockBean
+        UserRepository userRepository;
+
+        @Test
+        public void generic_message_test() {
+                ApiController apiController = new DummyController();
+                Object result = apiController.genericMessage("Hello World");
+                Object expected = Map.of("message", "Hello World");
+                assertEquals(expected,result);
+        }       
+
+        @Test
+        public void test_that_dummy_controller_returns_String1_when_1_is_passed() throws Exception {
+
+                // act
+                MvcResult response = mockMvc.perform(get("/dummycontroller?id=1"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                assertEquals("String1", response.getResponse().getContentAsString());
+        }
+
+        @Test
+        public void test_that_dummy_controller_returns_Exception_when_1_is_not_passed() throws Exception {
+
+                // act
+                MvcResult response = mockMvc.perform(get("/dummycontroller?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("String with id 7 not found", json.get("message"));
+        }
+
+}

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/DummyController.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/DummyController.java
@@ -1,0 +1,27 @@
+package edu.ucsb.cs156.rec.controllers;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.rec.errors.EntityNotFoundException;
+
+@RequestMapping("/dummycontroller")
+@RestController
+public class DummyController extends ApiController {
+
+    /**
+     * This method returns a single restaurant.
+     * 
+     * @param id id of the restaurant to get
+     * @return a single restaurant
+     */
+    @GetMapping("")
+    public String getById(@RequestParam Long id) throws EntityNotFoundException {
+        if (id == 1) {
+            return "String1";
+        }
+        throw new EntityNotFoundException(String.class, id);
+    }
+}


### PR DESCRIPTION
In this PR, I offer a solution to the problem that once you delete RestaurantController, etc. the abstract class ApiController and the EntityNotFoundException have testing gaps. 

This fixes that by putting tests in place for the code in ApiController and EntityNotFoundException that are not connected with any particular production code.  This makes the code base easier to maintain and reuse going forward.