### PR TITLE
Individual Roles for Users, Change Role Capabilities, User Table for Admins

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -73,6 +73,7 @@ function App() {
             />
           </>
         )}
+
         {hasRole(currentUser, "ROLE_USER") && (
           <>
             <Route

--- a/frontend/src/fixtures/usersFixtures.js
+++ b/frontend/src/fixtures/usersFixtures.js
@@ -13,6 +13,8 @@ const usersFixtures = {
       locale: "en",
       hostedDomain: "ucsb.edu",
       admin: true,
+      professor: false,
+      student: false,
     },
     {
       id: 2,
@@ -27,6 +29,8 @@ const usersFixtures = {
       locale: "en",
       hostedDomain: null,
       admin: false,
+      professor: true,
+      student: false,
     },
     {
       id: 3,
@@ -41,6 +45,8 @@ const usersFixtures = {
       locale: "en",
       hostedDomain: null,
       admin: false,
+      professor: false,
+      student: true,
     },
   ],
 };

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -2,6 +2,30 @@ import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
+  // Stryker disable all : hard to test for query caching
+  const toggleProfessorMutation = useBackendMutation(
+    cellToAxiosParamsToggleProfessor,
+    {},
+    ["/api/admin/users"],
+  );
+  // Toggle Professor User
+  function cellToAxiosParamsToggleProfessor(cell) {
+    return {
+      url: "/api/admin/users/toggleProfessor",
+      method: "POST",
+      params: {
+        id: cell.row.values.id,
+      },
+    };
+  }
+
+  // Stryker enable all
+
+  // Stryker disable next-line all
+  const toggleProfessorCallBack = (cell) => {
+    toggleProfessorMutation.mutate(cell);
+  };
+
   // Toggle Admin User
   function cellToAxiosParamsToggleAdmin(cell) {
     return {
@@ -23,30 +47,6 @@ export default function UsersTable({ users }) {
   // Stryker disable next-line all
   const toggleAdminCallBack = (cell) => {
     toggleAdminMutation.mutate(cell);
-  };
-
-  // Toggle Professor User
-  function cellToAxiosParamsToggleProfessor(cell) {
-    return {
-      url: "/api/admin/users/toggleProfessor",
-      method: "POST",
-      params: {
-        id: cell.row.values.id,
-      },
-    };
-  }
-
-  // Stryker disable all : hard to test for query caching
-  const toggleProfessorMutation = useBackendMutation(
-    cellToAxiosParamsToggleProfessor,
-    {},
-    ["/api/admin/users"],
-  );
-  // Stryker enable all
-
-  // Stryker disable next-line all
-  const toggleProfessorCallBack = (cell) => {
-    toggleProfessorMutation.mutate(cell);
   };
 
   // Toggle Student User

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,29 +1,130 @@
-import OurTable from "main/components/OurTable";
-
-const columns = [
-  {
-    Header: "id",
-    accessor: "id", // accessor is the "key" in the data
-  },
-  {
-    Header: "First Name",
-    accessor: "givenName",
-  },
-  {
-    Header: "Last Name",
-    accessor: "familyName",
-  },
-  {
-    Header: "Email",
-    accessor: "email",
-  },
-  {
-    Header: "Admin",
-    id: "admin",
-    accessor: (row, _rowIndex) => String(row.admin), // hack needed for boolean values to show up
-  },
-];
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
 
 export default function UsersTable({ users }) {
-  return <OurTable data={users} columns={columns} testid={"UsersTable"} />;
+  // Toggle Admin User
+  function cellToAxiosParamsToggleAdmin(cell) {
+    return {
+      url: "/api/admin/users/toggleAdmin",
+      method: "POST",
+      params: {
+        id: cell.row.values.id,
+      },
+    };
+  }
+  // Stryker disable all : hard to test for query caching
+  const toggleAdminMutation = useBackendMutation(
+    cellToAxiosParamsToggleAdmin,
+    {},
+    ["/api/admin/users"],
+  );
+  // Stryker enable all
+
+  // Stryker disable next-line all
+  const toggleAdminCallBack = (cell) => {
+    toggleAdminMutation.mutate(cell);
+  };
+
+  // Toggle Professor User
+  function cellToAxiosParamsToggleProfessor(cell) {
+    return {
+      url: "/api/admin/users/toggleProfessor",
+      method: "POST",
+      params: {
+        id: cell.row.values.id,
+      },
+    };
+  }
+
+  // Stryker disable all : hard to test for query caching
+  const toggleProfessorMutation = useBackendMutation(
+    cellToAxiosParamsToggleProfessor,
+    {},
+    ["/api/admin/users"],
+  );
+  // Stryker enable all
+
+  // Stryker disable next-line all
+  const toggleProfessorCallBack = (cell) => {
+    toggleProfessorMutation.mutate(cell);
+  };
+
+  // Toggle Student User
+  function cellToAxiosParamsToggleStudent(cell) {
+    return {
+      url: "/api/admin/users/toggleStudent",
+      method: "POST",
+      params: {
+        id: cell.row.values.id,
+      },
+    };
+  }
+
+  // Stryker disable all : hard to test for query caching
+  const toggleStudentMutation = useBackendMutation(
+    cellToAxiosParamsToggleStudent,
+    {},
+    ["/api/admin/users"],
+  );
+  // Stryker enable all
+
+  // Stryker disable next-line all
+  const toggleStudentCallBack = (cell) => {
+    toggleStudentMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+    {
+      Header: "First Name",
+      accessor: "givenName",
+    },
+    {
+      Header: "Last Name",
+      accessor: "familyName",
+    },
+    {
+      Header: "Email",
+      accessor: "email",
+    },
+    {
+      Header: "Admin",
+      id: "admin",
+      accessor: (row, _rowIndex) => String(row.admin), // hack needed for boolean values to show up
+    },
+    {
+      Header: "Professor",
+      id: "professor",
+      accessor: (row, _rowIndex) => String(row.professor),
+    },
+    {
+      Header: "Student",
+      id: "student",
+      accessor: (row, _rowIndex) => String(row.student),
+    },
+  ];
+
+  const buttonColumns = [
+    ...columns,
+    ButtonColumn("Toggle Admin", "primary", toggleAdminCallBack, "UsersTable"),
+    ButtonColumn(
+      "Toggle Professor",
+      "primary",
+      toggleProfessorCallBack,
+      "UsersTable",
+    ),
+    ButtonColumn(
+      "Toggle Student",
+      "primary",
+      toggleStudentCallBack,
+      "UsersTable",
+    ),
+  ];
+
+  return (
+    <OurTable data={users} columns={buttonColumns} testid={"UsersTable"} />
+  );
 }

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -1,21 +1,51 @@
 import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable";
 
 describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
   test("renders without crashing for empty table", () => {
-    render(<UsersTable users={[]} />);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UsersTable users={[]} />
+      </QueryClientProvider>,
+    );
   });
 
   test("renders without crashing for three users", () => {
-    render(<UsersTable users={usersFixtures.threeUsers} />);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UsersTable users={usersFixtures.threeUsers} />
+      </QueryClientProvider>,
+    );
   });
 
   test("Has the expected colum headers and content", () => {
-    render(<UsersTable users={usersFixtures.threeUsers} />);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <UsersTable users={usersFixtures.threeUsers} />
+      </QueryClientProvider>,
+    );
 
-    const expectedHeaders = ["id", "First Name", "Last Name", "Email", "Admin"];
-    const expectedFields = ["id", "givenName", "familyName", "email", "admin"];
+    const expectedHeaders = [
+      "id",
+      "First Name",
+      "Last Name",
+      "Email",
+      "Admin",
+      "Professor",
+      "Student",
+    ];
+    const expectedFields = [
+      "id",
+      "givenName",
+      "familyName",
+      "email",
+      "admin",
+      "professor",
+      "student",
+    ];
     const testId = "UsersTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -34,11 +64,23 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-admin`),
     ).toHaveTextContent("true");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-professor`),
+    ).toHaveTextContent("false");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-student`),
+    ).toHaveTextContent("false");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
       "2",
     );
     expect(
       screen.getByTestId(`${testId}-cell-row-1-col-admin`),
+    ).toHaveTextContent("false");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-professor`),
+    ).toHaveTextContent("true");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-student`),
     ).toHaveTextContent("false");
   });
 });

--- a/src/main/java/edu/ucsb/cs156/rec/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/rec/config/SecurityConfig.java
@@ -118,9 +118,12 @@ public class SecurityConfig {
           if (getAdmin(email)) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
           }
+          if (getProfessor(email)) {
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
+          }
 
-          if (email.endsWith("@ucsb.edu")) {
-            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
+          if (getStudent(email)) {
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_STUDENT"));
           }
         }
 
@@ -144,6 +147,29 @@ public class SecurityConfig {
     }
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getAdmin();
+  }
+  /**
+   * This method checks if the given email belongs to a professor user by querying
+   * the user repository.
+   * 
+   * @param email email address of the user
+   * @return whether the user with the given email is a professor
+   */
+  public boolean getProfessor(String email) {
+    Optional<User> u = userRepository.findByEmail(email);
+    return u.isPresent() && u.get().getProfessor();
+  }
+
+  /**
+   * This method checks if the given email belongs to a student user by querying
+   * the user repository.
+   * 
+   * @param email email address of the user
+   * @return whether the user with the given email is a student
+   */
+  public boolean getStudent(String email) {
+    Optional<User> u = userRepository.findByEmail(email);
+    return u.isPresent() && u.get().getStudent();
   }
 }
 

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/UsersController.java
@@ -6,14 +6,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.rec.errors.EntityNotFoundException;
 
 import edu.ucsb.cs156.rec.entities.User;
 import edu.ucsb.cs156.rec.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
 
 /**
  * This is a REST controller for getting information about the users.
@@ -44,5 +50,68 @@ public class UsersController extends ApiController {
         Iterable<User> users = userRepository.findAll();
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary = "Get user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/get")
+    public User users(
+            @Parameter(name = "id", description = "Long, id number of user to get", example = "1", required = true) @RequestParam Long id)
+            throws JsonProcessingException {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+        return user;
+    }
+
+    @Operation(summary = "Delete a user (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/delete")
+    public Object deleteUser_Admin(
+            @Parameter(name = "id", description = "Long, id number of user to delete", example = "1", required = true) @RequestParam Long id) {
+              User user = userRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+          userRepository.delete(user);
+
+        return genericMessage("User with id %s deleted".formatted(id));
+    }
+
+    
+    @Operation(summary = "Toggle the admin field") 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleAdmin")
+    public Object toggleAdmin( @Parameter(name = "id", description = "Long, id number of user to toggle their admin field", example = "1", required = true) @RequestParam Long id){
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setAdmin(!user.getAdmin());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled admin status to %s".formatted(id, user.getAdmin()));
+    }
+
+
+    @Operation(summary = "Toggle the professor field") 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleProfessor")
+    public Object toggleProfessor( @Parameter(name = "id", description = "Long, id number of user to toggle their professor field", example = "1", required = true) @RequestParam Long id){
+
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setProfessor(!user.getProfessor());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled professor status to %s".formatted(id, user.getProfessor()));
+    }
+
+    @Operation(summary = "Toggle the student field") 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleStudent")
+    public Object toggleStudent( @Parameter(name = "id") @RequestParam Long id){
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setStudent(!user.getStudent());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled student status to %s".formatted(id, user.getStudent()));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -32,5 +32,10 @@ public class User {
   private boolean emailVerified;
   private String locale;
   private String hostedDomain;
-  private boolean admin;
+  @Builder.Default
+  private boolean admin = false;
+  @Builder.Default
+  private boolean professor = false;
+  @Builder.Default
+  private boolean student = false;
 }

--- a/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptor.java
@@ -1,0 +1,87 @@
+package edu.ucsb.cs156.rec.interceptors;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import edu.ucsb.cs156.rec.repositories.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import edu.ucsb.cs156.rec.entities.User;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Slf4j
+@Component
+public class RoleInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // only process for users logged in using OAuth2  
+        if(authentication.getClass() == OAuth2AuthenticationToken.class){
+            // extract principle (aka. email, name, etc...)
+            OAuth2User principle =  ((OAuth2AuthenticationToken) authentication).getPrincipal();
+            String email = principle.getAttribute("email");
+
+            Optional<User> optionalUser = userRepository.findByEmail(email);
+           
+            // continue only if user is in db
+            if(optionalUser.isPresent()){
+                User user = optionalUser.get();
+
+                // Retrieve currently assigned ROLES for this user
+                Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+
+                // Strip user's current roles
+                Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
+                    grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
+                                && !grantedAuth.getAuthority().equals("ROLE_PROFESSOR") 
+                                && !grantedAuth.getAuthority().equals("ROLE_STUDENT"))
+                    .collect(Collectors.toSet());
+                
+                // Dynamically assign roles based on user's role in the database
+                if (user.getAdmin()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+                }
+                if (user.getProfessor()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
+                }
+                if (user.getStudent()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_STUDENT"));
+                }
+                
+                // Create new authentication object with revised roles
+                Authentication newAuthentication = new OAuth2AuthenticationToken( principle, revisedAuthorities, ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId());
+
+                // Replace the current oauth2 object with the new one, updated with new roles.
+                SecurityContextHolder.getContext().setAuthentication(newAuthentication);
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorConfig.java
+++ b/src/main/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorConfig.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.rec.interceptors;
+
+import javax.management.relation.Role;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Component
+public class RoleInterceptorConfig implements WebMvcConfigurer{
+
+    @Autowired
+    private RoleInterceptor roleInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(roleInterceptor);
+    }
+    
+}

--- a/src/main/java/edu/ucsb/cs156/rec/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/rec/repositories/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends CrudRepository<User, Long> {
    * @return Optional of User (empty if not found)
    */
   Optional<User> findByEmail(String email);
+  Iterable<User> findByProfessor(boolean professor);
+
 }

--- a/src/main/resources/db/migration/changes/Users.json
+++ b/src/main/resources/db/migration/changes/Users.json
@@ -97,6 +97,18 @@
                     "name": "PICTURE_URL",
                     "type": "VARCHAR(255)"
                   }
+                },
+                {
+                  "column": {
+                    "name": "PROFESSOR",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "STUDENT",
+                    "type": "BOOLEAN"
+                  }
                 }]
               ,
               "tableName": "USERS"

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/UsersControllerTests.java
@@ -13,14 +13,21 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -70,4 +77,362 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
 
   }
+
+  //new tests here
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void api_users__admin_logged_in__returns_a_user_that_exists() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+      User user1 = User.builder().email("cgaucho@ucsb.edu").id(42L).build();
+      when(userRepository.findById(eq(42L))).thenReturn(Optional.of(user1));
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/admin/users/get?id=42"))
+              .andExpect(status().isOk()).andReturn();
+
+      // assert
+
+      verify(userRepository, times(1)).findById(42L);
+      String expectedJson = mapper.writeValueAsString(user1);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void api_users__admin_logged_in__search_for_user_that_does_not_exist() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+
+      when(userRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/admin/users/get?id=7"))
+              .andExpect(status().isNotFound()).andReturn();
+
+      // assert
+
+      // verify(userRepository, times(1)).findById(7L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("EntityNotFoundException", json.get("type"));
+      assertEquals("User with id 7 not found", json.get("message"));
+  }
+
+
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_delete_a_user() throws Exception {
+          // arrange
+          User user1 = User.builder().email("cgaucho@ucsb.edu").id(15L).build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(user1));
+
+          // act
+          MvcResult response = mockMvc.perform(
+                          delete("/api/admin/users/delete?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).delete(any());
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_delete_non_existant_user_and_gets_right_error_message()
+                  throws Exception {
+          // arrange
+
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+          // act
+          MvcResult response = mockMvc.perform(
+                          delete("/api/admin/users/delete?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_admin_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(true)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled admin status to true", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_admin_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .admin(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled admin status to false", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggleAdmin_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleAdmin?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+  // professor toggle tests
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_professor_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(true)
+          .build();
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleProfessor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled professor status to true", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_professor_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .professor(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleProfessor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled professor status to false", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggle_professor_for_non_existant_user_and_gets_right_error_message() throws Exception {
+
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleProfessor?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+
+  // student toggle tests
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_student_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(true)
+          .build();
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleStudent?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled student status to true", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_student_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .student(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleStudent?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled student status to false", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggle_student_for_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleStudent?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
 }
+

--- a/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/interceptors/RoleInterceptorTests.java
@@ -1,0 +1,207 @@
+package edu.ucsb.cs156.rec.interceptors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import edu.ucsb.cs156.rec.entities.User;
+import edu.ucsb.cs156.rec.repositories.UserRepository;
+import edu.ucsb.cs156.rec.ControllerTestCase;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RoleInterceptorTests extends ControllerTestCase{
+    
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    private RequestMappingHandlerMapping mapping;
+
+    @BeforeEach
+    public void mockLogin(){
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", "cgaucho@ucsb.edu");
+        attributes.put("googleSub", "googleSub");
+        attributes.put("pictureUrl", "pictureUrl");
+        attributes.put("fullName", "fullName");
+        attributes.put("givenName", "givenName");
+        attributes.put("familyName", "familyName");
+        attributes.put("emailVerified", true);
+        attributes.put("locale", "locale");
+        attributes.put("hostedDomain", "hostedDomain");
+
+        Set<GrantedAuthority> authorities = new HashSet<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        authorities.add(new SimpleGrantedAuthority("ROLE_STUDENT"));
+        authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        authorities.add(new SimpleGrantedAuthority("ROLE_PROFESSOR"));
+
+
+        OAuth2User user = new DefaultOAuth2User(authorities, attributes, "email");
+        Authentication authentication = new OAuth2AuthenticationToken(user, authorities, "userRegistrationId");
+        SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    public void RoleInterceptorIsPresent() throws Exception{
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                .stream()
+                .filter(RoleInterceptor.class::isInstance)
+                .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+    }
+
+
+    @Test
+    public void updates_admin_role_when_user_admin_false() throws Exception{
+        User user = User.builder()
+                        .email("cgaucho@ucsb.edu")
+                        .id(15L)
+                        .admin(false)
+                        .professor(true)
+                        .student(true)
+                        .build();
+
+        when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                .stream()
+                .filter(RoleInterceptor.class::isInstance)
+                .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+
+        RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+
+        Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+
+        boolean role_admin = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+        boolean role_professor = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_PROFESSOR")); 
+        boolean role_student = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_STUDENT"));
+
+        assertFalse(role_admin, "ROLE_ADMIN should not be in roles list");
+        assertTrue(role_professor, "ROLE_PROFESSOR should not be in roles list");
+        assertTrue(role_student, "ROLE_STUDENT should not be in roles list");
+    }
+
+    @Test
+    public void updates_professor_role_when_user_professor_false() throws Exception{
+        User user = User.builder()
+                        .email("cgaucho@ucsb.edu")
+                        .id(15L)
+                        .admin(true)
+                        .professor(false)
+                        .student(false)
+                        .build();
+        
+        when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                .stream()
+                .filter(RoleInterceptor.class::isInstance)
+                .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+
+        RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+        
+        verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+
+        Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+
+        boolean role_admin = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+        boolean role_professor = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_PROFESSOR")); 
+        boolean role_student = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_STUDENT"));
+
+        assertTrue(role_admin, "ROLE_ADMIN should be in roles list");
+        assertFalse(role_professor, "ROLE_PROFESSOR should not be in roles list");
+        assertFalse(role_student, "ROLE_STUDENT should not be in roles list");
+    }
+    
+    @Test
+    public void updates_nothing_when_user_not_present() throws Exception {
+        User user = User.builder()
+                        .email("cgaucho2@ucsb.edu")
+                        .id(15L)
+                        .admin(false)
+                        .professor(false)
+                        .student(false)
+                        .build();
+
+        when(userRepository.findByEmail("cgaucho2@ucsb.edu")).thenReturn(Optional.of(user));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                        .stream()
+                        .filter(RoleInterceptor.class::isInstance)
+                        .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+
+        RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+        
+        Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+
+        boolean role_admin = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+        boolean role_professor = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_PROFESSOR")); 
+        boolean role_student = authorities.stream().anyMatch(a -> a.getAuthority().equals("ROLE_STUDENT"));
+
+        assertTrue(role_admin, "ROLE_ADMIN should not be in roles list");
+        assertTrue(role_professor, "ROLE_PROFESSOR should not be in roles list");
+        assertTrue(role_student, "ROLE_STUDENT should not be in roles list");
+    }
+}


### PR DESCRIPTION
# Closes #12 : Show individual user roles on admin User Table

Dokku: https://proj-rec-qa.dokku-06.cs.ucsb.edu

This PR adds a Professor Role and Student Role for Users and the capability to change the roles of users by admins.

**Backend Changes** ( passes all jacoco and pit mutation testing )
- User Entity now includes booleans for professor & student roles
- User Repository has a findbyEmail method
- User change-set json has columns for professor & student booleans
- Edited Security Config to handle the addition roles
- Adds RoleInterceptor.java and RoleInterceptorConfig.java for dynamically changing roles
- Adds testing for Role Interceptor in  RoleInterceptorTests.java
- User Controller has 3 new endpoints for toggling each role, as well as tests for new points

**Frontend Changes** ( passes coverage and stryker mutation testing )
- User Table now has 2 new columns to display boolean for professor & student, 3 new botton columns for toggling each role
- Additional tests for User Table to test display of new columns and new buttons.
- User fixture now includes values for professor and student booleans

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/2d5f6f6b-3b8c-419f-afa0-da13a39f1845">

This PR is especially long because we chose this as our first issue to work on and we didn't split the work correctly, leading to many people needing to depend on other people's work to test their own work, which is why we decided to consolidate all our changes into one branch. In future issues, we will split it in a more proper manner.