### PR TITLE
eg - professor tab on navbar, three placeholders pages for pending requests, completed requests, and statistics pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,8 @@ import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminRequestsPage from "main/pages/AdminRequestsPage";
+import ProfessorCompletedRequestsPage from "main/pages/Professor/ProfessorCompletedRequestsPage"
+import ProfessorStatisticsPage from "main/pages/Professor/ProfessorStatisticsPage"
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -22,6 +24,12 @@ function App() {
         )}
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <Route exact path="/admin/requests" element={<AdminRequestsPage />} />
+        )}
+        {hasRole(currentUser, "ROLE_PROFESSOR") && (
+          <Route exact path="/requests/completed" element={<ProfessorCompletedRequestsPage />} />
+        )}
+        {hasRole(currentUser, "ROLE_PROFESSOR") && (
+          <Route exact path="/requests/statistics" element={<ProfessorStatisticsPage />} />
         )}
       </Routes>
     </BrowserRouter>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminRequestsPage from "main/pages/AdminRequestsPage";
 import ProfessorCompletedRequestsPage from "main/pages/Professor/ProfessorCompletedRequestsPage";
 import ProfessorStatisticsPage from "main/pages/Professor/ProfessorStatisticsPage";
+import ProfessorPendingRequestsPage from "main/pages/Professor/ProfessorPendingRequestsPage";
 
 import RequestTypeIndexPage from "main/pages/RequestType/RequestTypeIndexPage";
 import RequestTypeCreatePage from "main/pages/RequestType/RequestTypeCreatePage";
@@ -51,6 +52,13 @@ function App() {
         )}
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <Route exact path="/admin/requests" element={<AdminRequestsPage />} />
+        )}
+        {hasRole(currentUser, "ROLE_PROFESSOR") && (
+          <Route
+            exact
+            path="/requests/pending"
+            element={<ProfessorPendingRequestsPage />}
+          />
         )}
         {hasRole(currentUser, "ROLE_PROFESSOR") && (
           <Route

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,8 +3,8 @@ import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminRequestsPage from "main/pages/AdminRequestsPage";
-import ProfessorCompletedRequestsPage from "main/pages/Professor/ProfessorCompletedRequestsPage"
-import ProfessorStatisticsPage from "main/pages/Professor/ProfessorStatisticsPage"
+import ProfessorCompletedRequestsPage from "main/pages/Professor/ProfessorCompletedRequestsPage";
+import ProfessorStatisticsPage from "main/pages/Professor/ProfessorStatisticsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -26,10 +26,18 @@ function App() {
           <Route exact path="/admin/requests" element={<AdminRequestsPage />} />
         )}
         {hasRole(currentUser, "ROLE_PROFESSOR") && (
-          <Route exact path="/requests/completed" element={<ProfessorCompletedRequestsPage />} />
+          <Route
+            exact
+            path="/requests/completed"
+            element={<ProfessorCompletedRequestsPage />}
+          />
         )}
         {hasRole(currentUser, "ROLE_PROFESSOR") && (
-          <Route exact path="/requests/statistics" element={<ProfessorStatisticsPage />} />
+          <Route
+            exact
+            path="/requests/statistics"
+            element={<ProfessorStatisticsPage />}
+          />
         )}
       </Routes>
     </BrowserRouter>

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -13,6 +13,7 @@ const apiCurrentUserFixtures = {
       locale: "en",
       hostedDomain: "ucsb.edu",
       admin: true,
+      professor: true,
     },
     roles: [
       {
@@ -44,6 +45,9 @@ const apiCurrentUserFixtures = {
       },
       {
         authority: "ROLE_ADMIN",
+      },
+      {
+        authority: "ROLE_PROFESSOR",
       },
     ],
   },
@@ -118,6 +122,7 @@ const currentUserFixtures = {
         "SCOPE_https://www.googleapis.com/auth/userinfo.email",
         "ROLE_USER",
         "ROLE_ADMIN",
+        "ROLE_PROFESSOR",
       ],
     },
   },

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -61,15 +61,21 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                 </NavDropdown>
               )}
-             {hasRole(currentUser, "ROLE_PROFESSOR") && (
+              {hasRole(currentUser, "ROLE_PROFESSOR") && (
                 <NavDropdown
                   title="Professor"
                   id="appnavbar-professor-dropdown"
                   data-testid="appnavbar-professor-dropdown"
                 >
-                  <NavDropdown.Item href="/requests/pending">Pending Requests</NavDropdown.Item>
-                  <NavDropdown.Item href="/requests/completed">Completed Requests</NavDropdown.Item>
-                  <NavDropdown.Item href="/requests/statistics">Statistics</NavDropdown.Item>
+                  <NavDropdown.Item href="/requests/pending">
+                    Pending Requests
+                  </NavDropdown.Item>
+                  <NavDropdown.Item href="/requests/completed">
+                    Completed Requests
+                  </NavDropdown.Item>
+                  <NavDropdown.Item href="/requests/statistics">
+                    Statistics
+                  </NavDropdown.Item>
                 </NavDropdown>
               )}
             </Nav>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -61,6 +61,17 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                 </NavDropdown>
               )}
+             {hasRole(currentUser, "ROLE_PROFESSOR") && (
+                <NavDropdown
+                  title="Professor"
+                  id="appnavbar-professor-dropdown"
+                  data-testid="appnavbar-professor-dropdown"
+                >
+                  <NavDropdown.Item href="/requests/pending">Pending Requests</NavDropdown.Item>
+                  <NavDropdown.Item href="/requests/completed">Completed Requests</NavDropdown.Item>
+                  <NavDropdown.Item href="/requests/statistics">Statistics</NavDropdown.Item>
+                </NavDropdown>
+              )}
             </Nav>
 
             <Nav className="ml-auto">

--- a/frontend/src/main/pages/Professor/ProfessorCompletedRequestsPage.js
+++ b/frontend/src/main/pages/Professor/ProfessorCompletedRequestsPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+import { useBackend } from "main/utils/useBackend";
+const ProfessorCompletedRequestsPage = () => {
+  const { error: _error, status: _status } = useBackend();
+  // Stryker disable next-line all : don't test internal caching of React Query
+
+  return (
+    <BasicLayout>
+      <h2>Completed Requests</h2>
+    </BasicLayout>
+  );
+};
+
+export default ProfessorCompletedRequestsPage;

--- a/frontend/src/main/pages/Professor/ProfessorPendingRequestsPage.js
+++ b/frontend/src/main/pages/Professor/ProfessorPendingRequestsPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+import { useBackend } from "main/utils/useBackend";
+const ProfessorPendingRequestsPage = () => {
+  const { error: _error, status: _status } = useBackend();
+  // Stryker disable next-line all : don't test internal caching of React Query
+
+  return (
+    <BasicLayout>
+      <h2>Pending Requests</h2>
+    </BasicLayout>
+  );
+};
+
+export default ProfessorPendingRequestsPage;

--- a/frontend/src/main/pages/Professor/ProfessorStatisticsPage.js
+++ b/frontend/src/main/pages/Professor/ProfessorStatisticsPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+import { useBackend } from "main/utils/useBackend";
+const ProfessorStatisticsPage = () => {
+  const { error: _error, status: _status } = useBackend();
+  // Stryker disable next-line all : don't test internal caching of React Query
+
+  return (
+    <BasicLayout>
+      <h2>Statistics</h2>
+    </BasicLayout>
+  );
+};
+
+export default ProfessorStatisticsPage;

--- a/frontend/src/stories/pages/Professor/ProfessorCompletedRequestsPage.stories.js
+++ b/frontend/src/stories/pages/Professor/ProfessorCompletedRequestsPage.stories.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ProfessorCompletedRequestsPage from "main/pages/Professor/ProfessorCompletedRequestsPage";
+
+export default {
+  title: "pages/Professor/ProfessorCompletedRequestsPage",
+  component: ProfessorCompletedRequestsPage,
+};
+
+const Template = () => <ProfessorCompletedRequestsPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    // post requests when backend is done
+  ],
+};

--- a/frontend/src/stories/pages/Professor/ProfessorPendingRequestsPage.stories.js
+++ b/frontend/src/stories/pages/Professor/ProfessorPendingRequestsPage.stories.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ProfessorPendingRequestsPage from "main/pages/Professor/ProfessorPendingRequestsPage";
+
+export default {
+  title: "pages/Professor/ProfessorPendingRequestsPage",
+  component: ProfessorPendingRequestsPage,
+};
+
+const Template = () => <ProfessorPendingRequestsPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/Professor/ProfessorStatisticsPage.stories.js
+++ b/frontend/src/stories/pages/Professor/ProfessorStatisticsPage.stories.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ProfessorStatisticsPage from "main/pages/Professor/ProfessorStatisticsPage";
+
+export default {
+  title: "pages/Professor/ProfessorStatisticsPage",
+  component: ProfessorStatisticsPage,
+};
+
+const Template = () => <ProfessorStatisticsPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-import usersFixtures from "fixtures/usersFixtures";
 
 import AppNavbar from "main/components/Nav/AppNavbar";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import usersFixtures from "fixtures/usersFixtures";
 
 import AppNavbar from "main/components/Nav/AppNavbar";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -38,6 +39,23 @@ describe("AppNavbar tests", () => {
 
     await screen.findByText("Welcome, phtcon@ucsb.edu");
     const adminMenu = screen.getByTestId("appnavbar-admin-dropdown");
+    expect(adminMenu).toBeInTheDocument();
+  });
+
+  test("renders correctly for professor user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Welcome, phtcon@ucsb.edu");
+    const adminMenu = screen.getByTestId("appnavbar-professor-dropdown");
     expect(adminMenu).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/pages/Professor/ProfessorCompletedRequestsPage.test.js
+++ b/frontend/src/tests/pages/Professor/ProfessorCompletedRequestsPage.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import ProfessorCompletedRequestsPage from "main/pages/Professor/ProfessorCompletedRequestsPage";
+// import request fixtures when they are done
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ProfessorCompletedRequestsPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  // add tests for frontend table when backend its done
+
+  test("renders empty page with title", async () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ProfessorCompletedRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Completed Requests");
+  });
+});

--- a/frontend/src/tests/pages/Professor/ProfessorPendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Professor/ProfessorPendingRequestsPage.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import ProfessorPendingRequestsPage from "main/pages/Professor/ProfessorPendingRequestsPage";
+// import request fixtures when they are done
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ProfessorPendingRequestsPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  // add tests for frontend table when backend its done
+
+  test("renders empty page with title", async () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ProfessorPendingRequestsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Pending Requests");
+  });
+});

--- a/frontend/src/tests/pages/Professor/ProfessorStatisticsPage.test.js
+++ b/frontend/src/tests/pages/Professor/ProfessorStatisticsPage.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import ProfessorStatisticsPage from "main/pages/Professor/ProfessorStatisticsPage";
+// import request fixtures when they are done
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ProfessorStatisticsPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  // add tests for frontend table when backend its done
+
+  test("renders empty page with title", async () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ProfessorStatisticsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Statistics");
+  });
+});


### PR DESCRIPTION
Closes #89, Closes #90, Closes #91, Closes #95

Dokku deployment: https://proj-rec-elexg.dokku-06.cs.ucsb.edu/
Storybook: https://6734fdad790fe98dc6bf77f1-vijmfyxinv.chromatic.com/?path=/docs/pages-professor-professorcompletedrequestspage--docs

Creates a new tab for professor users. Professor tab links to these urls:
/requests/pending, 
/requests/completed
/requests/statistics

This PR also creates three placeholder pages, one for each link.

Also adds tests for the placeholder pages. Right now it just makes sure that the pages render with the correct title

Additionally, there is a small update to currentUsersFixtures which adds professor role to ensure full coverage for tests.

Frontend changes: 
Professor Tab. Toggle professor role in the admin menu and you will see this professor tab.
![Screenshot 2024-11-25 115800](https://github.com/user-attachments/assets/0785a25b-689d-42d6-b3b8-bd75a6684267)

Pending Requests Placeholder 
![Screenshot 2024-11-29 153150](https://github.com/user-attachments/assets/65972c05-34fb-4183-b5f4-98f286992495)

Completed Requests Placeholder
![Screenshot 2024-11-25 120314](https://github.com/user-attachments/assets/bb5d1256-cef4-4c6b-aa24-411c52cdc995)

Statistics Placeholder
![Screenshot 2024-11-25 120322](https://github.com/user-attachments/assets/b864ab48-9009-4370-a639-43f65b1c0384)